### PR TITLE
Create 2018-08-08.md

### DIFF
--- a/2018-08-08.md
+++ b/2018-08-08.md
@@ -1,0 +1,3 @@
+Q:Master节点到集群有几种通信方式？
+A:从Master (apiserver)到集群有两个主要的通信路径。第一个是从apiserver到在集群中的每个节点上运行的kubelet进程。第二个是通过apiserver的代理功能从apiserver到任何node、pod或service 。
+R:http://docs.kubernetes.org.cn/306.html


### PR DESCRIPTION
Q:Master节点到集群有几种通信方式？ A:从Master (apiserver)到集群有两个主要的通信路径。第一个是从apiserver到在集群中的每个节点上运行的kubelet进程。第二个是通过apiserver的代理功能从apiserver到任何node、pod或service 。 R:http://docs.kubernetes.org.cn/306.html